### PR TITLE
fixing registry and global dns resolution

### DIFF
--- a/install-openshift.sh
+++ b/install-openshift.sh
@@ -224,6 +224,9 @@ touch /etc/origin/master/htpasswd
 ansible-playbook -i inventory.ini openshift-ansible/playbooks/prerequisites.yml
 ansible-playbook -i inventory.ini openshift-ansible/playbooks/deploy_cluster.yml
 
+
+
+
 htpasswd -b /etc/origin/master/htpasswd ${USERNAME} ${PASSWORD}
 oc adm policy add-cluster-role-to-user cluster-admin ${USERNAME}
 
@@ -257,3 +260,12 @@ echo "$ oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:$API_PORT
 echo "******"
 
 oc login -u ${USERNAME} -p ${PASSWORD} https://console.$DOMAIN:$API_PORT/
+
+#Comment all entries in /etc/resolv.conf and inlcude `nameserver 192.168.1.8`. Make /etc/resolv.conf readonly to avoid overwriting by origin
+sed -i s/^/"#"/g resolv.conf
+echo "nameserver $IP" >> resolv.conf
+chattr +i /etc/resolv.conf
+
+#Add  registry pod IP to /etc/hosts for registry dns resolution 
+registryIP=$(oc get service/docker-registry -n default -o json | grep clusterIP | awk '{split($0,array,":")} END{print array[2]}')
+echo "$registryIP docker-registry.default.svc" | tr -d "\"","," >> resolv.conf


### PR DESCRIPTION
Either origin registry is not resolved or all external domains like github.com are not resolved by openshift resources like pods. /etc/resolv.conf is updated automatically by origin to add search entries.